### PR TITLE
Creates bootMultipleStapler to allow for custom booting

### DIFF
--- a/src/Models/MultipleFileTrait.php
+++ b/src/Models/MultipleFileTrait.php
@@ -54,9 +54,23 @@ trait MultipleFileTrait
     }
 
     /**
-     * Instance's boot method
+     * The "booting" method of the model.
      */
     public static function boot()
+    {
+        parent::boot();
+
+        static::bootMultipleStapler();
+    }
+
+    /**
+     * Register eloquent event handlers.
+     * We'll spin through each of the attached files defined on this class
+     * and register callbacks for the events we need to observe in order to
+     * handle file uploads.
+     */
+
+    public static function bootMultipleStapler()
     {
         parent::boot();
 


### PR DESCRIPTION
Fix para los casos que se tiene un método static boot dentro del modelo, lo cual ocasiona que el método boot de MultipleFileTrait no sea llamado.

El caso es igual al que se comenta en https://github.com/CodeSleeve/stapler/blob/master/docs/troubleshooting.md